### PR TITLE
Allow message to be sent before connection is closed

### DIFF
--- a/plugins/module_utils/network/skydive/api.py
+++ b/plugins/module_utils/network/skydive/api.py
@@ -183,7 +183,7 @@ class skydive_inject_protocol(object):
                 msg="Error during topology update %s" % e, **result
             )
         finally:
-            self.stop()
+            self.stop_when_complete()
 
 
 class skydive_wsclient(skydive_client_check):


### PR DESCRIPTION
##### SUMMARY
Wait to message to be sent before closing the connection

##### ISSUE TYPE
- Bugfix Pull Request

##### ADDITIONAL INFORMATION
Using "self.stop()" closes the connection before the websocket message
could be send.
The removal of this call removes also the close message send via
websockets, but Skydive analyzer looks like handle it correctly.
Log of the analyzer:
Successfully removed client host-test for pool /ws/publisher type : [*websocket.Pool]