### PR TITLE
Migrate to REST API. Removed 'update' state

### DIFF
--- a/plugins/modules/skydive_edge.py
+++ b/plugins/modules/skydive_edge.py
@@ -45,6 +45,10 @@ options:
     - To define the host of the node.
     default: ''
     required: false
+  seed:
+    description:
+    - used to generate the UUID of the node
+    default: ''
   metadata:
     description:
     - To define metadata for the edge.
@@ -178,6 +182,7 @@ def main():
         parent_node=dict(type="str", required=True),
         child_node=dict(type="str", required=True),
         host=dict(type="str", default=""),
+        seed=dict(required=False, ib_req=True, default=""),
         metadata=dict(type="dict", default=dict()),
     )
 

--- a/plugins/modules/skydive_node.py
+++ b/plugins/modules/skydive_node.py
@@ -48,12 +48,11 @@ options:
     required: false
   state:
     description:
-    - State of the Skydive Node. If value is I(present) new node will be created else
-      if it is I(absent) it will be deleted.
+    - State of the Skydive Node. If value is I(present) new node will be created, or
+      metadata modified if it is different. If it is I(absent) node will be deleted.
     default: present
     choices:
     - present
-    - update
     - absent
 """
 
@@ -78,7 +77,7 @@ EXAMPLES = """
     seed: TOR1
     metadata:
       Model: Cisco 3400
-    state: update
+    state: present
     provider:
       endpoint: localhost:8082
       username: admin
@@ -119,7 +118,7 @@ def main():
 
     argument_spec = dict(
         provider=dict(required=False),
-        state=dict(default="present", choices=["present", "update", "absent"]),
+        state=dict(default="present", choices=["present", "absent"]),
     )
 
     argument_spec.update(ib_spec)


### PR DESCRIPTION
Since skydive commit 7dc363cc25 (in master, not released yet), node and
edge APIs are exposed also with a REST API.
Using this API makes more sense for this modules, as it only make one
operation and do not need to stay connected to receive messages (as
websockets do).

This PR also uses the PATCH method (still a PR:
https://github.com/skydive-project/skydive/pull/2263) to update
nodes/edges generating a list of JSON patches for the keys found in the
metadata key.
Keys defined in metadata will modify the stored node/edge.
Other metadata values in the stored node/edge will remaing unmodified.

'update' state is removed, so modules behave similar to others ansible
modules ('file' for example).
Now 'present' state will create or update nodes/edges.
Breaking change that should be reported to users.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
